### PR TITLE
association support

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -11,4 +11,15 @@ require "tako"
 # Pry.start
 
 require "irb"
+
+require File.join(File.dirname(__FILE__), "../../", "spec/support/model_class")
+
+ENV["RAILS_ENV"] ||= 'test'
+ENV['TAKO_CONFIG_FILE_PATH'] ||= File.join(File.dirname(__FILE__), "../", "spec/config/shards.yml")
+
+database_yml_path = File.join(File.dirname(__FILE__), "../", "spec/config/database.yml")
+database_yml = YAML.load(ERB.new(File.read(database_yml_path)).result).with_indifferent_access[:test]
+Tako.load_connections_from_yaml
+ActiveRecord::Base.establish_connection(database_yml)
+
 IRB.start

--- a/bin/console
+++ b/bin/console
@@ -10,7 +10,7 @@ require "tako"
 # require "pry"
 # Pry.start
 
-require "irb"
+require "pry"
 
 require File.join(File.dirname(__FILE__), "../../", "spec/support/model_class")
 
@@ -22,4 +22,5 @@ database_yml = YAML.load(ERB.new(File.read(database_yml_path)).result).with_indi
 Tako.load_connections_from_yaml
 ActiveRecord::Base.establish_connection(database_yml)
 
-IRB.start
+opts = Pry::CLI.parse_options
+Pry::CLI.start(opts)

--- a/lib/tako.rb
+++ b/lib/tako.rb
@@ -46,6 +46,15 @@ end
 
 ActiveRecord::Base.class_eval do
   extend Tako::ActiveRecordExt::Base::ClassMethods
+  include Tako::ActiveRecordExt::Base::InstanceMethods
+end
+
+ActiveRecord::Associations::CollectionAssociation.class_eval do
+  prepend Tako::ActiveRecordExt::Association::Overrides
+end
+
+ActiveRecord::Associations::SingularAssociation.class_eval do
+  prepend Tako::ActiveRecordExt::Association::Overrides
 end
 
 ActiveRecord::LogSubscriber.class_eval do

--- a/lib/tako.rb
+++ b/lib/tako.rb
@@ -47,14 +47,27 @@ end
 ActiveRecord::Base.class_eval do
   extend Tako::ActiveRecordExt::Base::ClassMethods
   include Tako::ActiveRecordExt::Base::InstanceMethods
+  include Tako::ActiveRecordExt::Base::Overrides
+end
+
+ActiveRecord::Associations::Association.class_eval do
+  include Tako::ActiveRecordExt::Association::Overrides
 end
 
 ActiveRecord::Associations::CollectionAssociation.class_eval do
-  prepend Tako::ActiveRecordExt::Association::Overrides
+  include Tako::ActiveRecordExt::CollectionAssociation::Overrides
 end
 
 ActiveRecord::Associations::SingularAssociation.class_eval do
-  prepend Tako::ActiveRecordExt::Association::Overrides
+  include Tako::ActiveRecordExt::SingularAssociation::Overrides
+end
+
+ActiveRecord::Associations::CollectionProxy.class_eval do
+  include Tako::ActiveRecordExt::CollectionProxy::Overrides
+end
+
+ActiveRecord::AssociationRelation.class_eval do
+  include Tako::ActiveRecordExt::AssociationRelation::Overrides
 end
 
 ActiveRecord::LogSubscriber.class_eval do

--- a/lib/tako/proxy.rb
+++ b/lib/tako/proxy.rb
@@ -2,12 +2,10 @@ module Tako
   class Proxy
     attr_reader :shard_name
     attr_reader :connection
-    attr_accessor :base
 
-    def initialize(shard_name, connection, base)
+    def initialize(shard_name, connection)
       @shard_name = shard_name
       @connection = connection
-      @base = base
     end
 
     def in_proxy

--- a/lib/tako/proxy_stack.rb
+++ b/lib/tako/proxy_stack.rb
@@ -6,12 +6,12 @@ module Tako
       end
 
       def in_piles(proxy)
-        proxy.base ||= @current
+        previous ||= @current
         @current = proxy
 
         yield
       ensure
-        @current = @current.base
+        @current = previous
       end
     end
   end

--- a/lib/tako/repository.rb
+++ b/lib/tako/repository.rb
@@ -21,8 +21,8 @@ module Tako
         proxy_configs[shard_name] = conf
       end
 
-      def shard(shard_name, base = nil)
-        Proxy.new(shard_name, proxy_connections[shard_name.to_sym], base)
+      def shard(shard_name)
+        Proxy.new(shard_name, proxy_connections[shard_name.to_sym])
       end
 
       def shard_names

--- a/spec/active_record/shard.rb
+++ b/spec/active_record/shard.rb
@@ -139,23 +139,26 @@ describe 'ActiveRecord::Base.shard' do
         # calclate methods
         expect(ModelA.shard(:shard01).average(:value1)).to eq(1.5)
         expect(ModelA.shard(:shard02).average(:value1)).to eq(1.3333)
+
+        # reload
+        expect(ModelA.shard(:shard01).where(value2: "Huga2").where(value1: 1).reload.first).to be_nil
       end
     end
   end
 
   describe "force_shard" do
     subject do
-      User.shard(:shard01).create(id: 1)
-      User.shard(:shard02).create(id: 2)
+      ForceShardRoot.shard(:shard01).create(id: 1)
+      ForceShardRoot.shard(:shard02).create(id: 2)
 
-      Wallet.shard(:shard01).create(user_id: 1)
-      Wallet.shard(:shard02).create(user_id: 2)
+      ForceShardA.shard(:shard01).create(force_shard_root_id: 1)
+      ForceShardA.shard(:shard02).create(force_shard_root_id: 2)
 
-      Log.shard(:shard01).create(user_id: 1)
-      log = Log.shard(:shard02).create(user_id: 2)
+      ForceShardB.shard(:shard01).create(force_shard_root_id: 1)
+      b = ForceShardB.shard(:shard02).create(force_shard_root_id: 2)
 
-      Log.sharded_class_method(3)
-      log.sharded_method(4)
+      ForceShardB.sharded_class_method(3)
+      b.sharded_method(4)
       # turn off for force sharding
       allow(ActiveRecord::Base).to receive(:force_shard?).and_return(false)
     end
@@ -164,58 +167,165 @@ describe 'ActiveRecord::Base.shard' do
       aggregate_failures do
         subject
 
-        expect(User.shard(:shard01).find_by(id: 1)).to be_present
-        expect(User.shard(:shard01).find_by(id: 2)).to be_blank
-        expect(User.shard(:shard02).find_by(id: 1)).to be_blank
-        expect(User.shard(:shard02).find_by(id: 2)).to be_present
+        expect(ForceShardRoot.shard(:shard01).find_by(id: 1)).to be_present
+        expect(ForceShardRoot.shard(:shard01).find_by(id: 2)).to be_blank
+        expect(ForceShardRoot.shard(:shard02).find_by(id: 1)).to be_blank
+        expect(ForceShardRoot.shard(:shard02).find_by(id: 2)).to be_present
 
-        expect(Wallet.shard(:shard01).find_by(user_id: 1)).to be_present
-        expect(Wallet.shard(:shard01).find_by(user_id: 2)).to be_present
-        expect(Wallet.shard(:shard02).find_by(user_id: 1)).to be_blank
-        expect(Wallet.shard(:shard02).find_by(user_id: 2)).to be_blank
+        expect(ForceShardA.shard(:shard01).find_by(force_shard_root_id: 1)).to be_present
+        expect(ForceShardA.shard(:shard01).find_by(force_shard_root_id: 2)).to be_present
+        expect(ForceShardA.shard(:shard02).find_by(force_shard_root_id: 1)).to be_blank
+        expect(ForceShardA.shard(:shard02).find_by(force_shard_root_id: 2)).to be_blank
 
-        expect(Log.shard(:shard01).find_by(user_id: 1)).to be_blank
-        expect(Log.shard(:shard01).find_by(user_id: 2)).to be_blank
-        expect(Log.shard(:shard01).find_by(user_id: 3)).to be_blank
-        expect(Log.shard(:shard01).find_by(user_id: 4)).to be_blank
-        expect(Log.shard(:shard02).find_by(user_id: 1)).to be_present
-        expect(Log.shard(:shard02).find_by(user_id: 2)).to be_present
-        expect(Log.shard(:shard02).find_by(user_id: 3)).to be_present
-        expect(Log.shard(:shard02).find_by(user_id: 4)).to be_present
+        expect(ForceShardB.shard(:shard01).find_by(force_shard_root_id: 1)).to be_blank
+        expect(ForceShardB.shard(:shard01).find_by(force_shard_root_id: 2)).to be_blank
+        expect(ForceShardB.shard(:shard01).find_by(force_shard_root_id: 3)).to be_blank
+        expect(ForceShardB.shard(:shard01).find_by(force_shard_root_id: 4)).to be_blank
+        expect(ForceShardB.shard(:shard02).find_by(force_shard_root_id: 1)).to be_present
+        expect(ForceShardB.shard(:shard02).find_by(force_shard_root_id: 2)).to be_present
+        expect(ForceShardB.shard(:shard02).find_by(force_shard_root_id: 3)).to be_present
+        expect(ForceShardB.shard(:shard02).find_by(force_shard_root_id: 4)).to be_present
       end
     end
   end
 
-  describe "assosiations" do
-    subject do
-      Tako.shard(:shard01) do
-        blog = Blog.create(id: 1)
-        blog.author || blog.build_author.save!
-        blog.articles << Article.new(id: 1)
-        blog.articles << Article.new(id: 2)
-        blog.articles << Article.new(id: 3)
-      end
+  describe "has_many association" do
+    it "works" do
+      aggregate_failures do
+        expect(User.shard(:shard01).find_by(id: 1)).to be_blank
 
-      blog = Blog.shard(:shard02).create(id: 2)
-      blog.create_author
-      blog.articles << Article.new(id: 4)
-      blog.articles << Article.new(id: 5)
-      blog.articles << Article.new(id: 6)
+        user = User.shard(:shard01).create(id: 1)
+
+        expect(User.find_by(id: 1)).to be_blank
+        expect(User.shard(:shard01).find_by(id: 1)).to be_present
+        expect(User.shard(:shard02).find_by(id: 1)).to be_blank
+        expect(user.logs).to be_blank
+        expect(user.logs.count).to eq(0)
+        expect(Log.shard(:shard01).find_by(id: 1)).to be_blank
+        expect(Log.shard(:shard02).find_by(id: 2)).to be_blank
+        expect(Log.shard(:shard01).new(id: 1).current_shard).to eq(:shard01)
+
+        user.logs << Log.shard(:shard01).new(id: 1)
+        user.logs << Log.shard(:shard02).new(id: 2)
+
+        expect(user.logs).to be_present
+        expect(user.logs.count).to eq(1)
+        expect(Log.find_by(id: 1)).to be_blank
+        expect(Log.shard(:shard01).find_by(id: 1)).to be_present
+        expect(Log.shard(:shard02).find_by(id: 1)).to be_blank
+        expect(Log.shard(:shard01).find_by(id: 2)).to be_blank
+        expect(Log.shard(:shard02).find_by(id: 2)).to be_present
+
+        Log.shard(:shard01).new(id: 2, user: user).save
+
+        expect(Log.find_by(id: 2)).to be_blank
+        expect(Log.shard(:shard01).find_by(id: 2)).to be_present
+        expect(user.reload.logs.reload.count).to eq(2)
+      end
+    end
+  end
+
+  describe "has_one association" do
+    it "works" do
+      aggregate_failures do
+        expect(User.shard(:shard01).find_by(id: 1)).to be_blank
+
+        user = User.shard(:shard01).create(id: 1)
+
+        # User(id: 1) should be persisted in shard01
+        expect(User.find_by(id: 1)).to be_blank
+        expect(User.shard(:shard01).find_by(id: 1)).to be_present
+        expect(User.shard(:shard02).find_by(id: 1)).to be_blank
+        expect(user.wallet).to be_blank
+
+        user.build_wallet(id: 1)
+
+        expect(user.wallet).to be_present
+        expect(user.wallet).to_not be_persisted
+        expect(user.wallet.current_shard).to eq(:shard01)
+        expect(Wallet.find_by(id: 1)).to be_blank
+        expect(Wallet.shard(:shard01).find_by(id: 1)).to be_blank
+        expect(Wallet.shard(:shard02).find_by(id: 1)).to be_blank
+
+        user.wallet.save
+
+        expect(user.wallet).to be_persisted
+        expect(Wallet.find_by(id: 1)).to be_blank
+        expect(Wallet.shard(:shard01).find_by(id: 1)).to be_present
+        expect(Wallet.shard(:shard02).find_by(id: 1)).to be_blank
+        expect(user.reload.wallet.reload).to be_present
+      end
     end
 
-    it "where chain works" do
+    it "works" do
       aggregate_failures do
-        subject
+        blog_shard1 = Blog.shard(:shard01).create(id: 1)
 
-        blog_shard1 = Blog.shard(:shard01).first
+        expect(blog_shard1.author).to be_blank
+        expect(Author.shard(:shard01).find_by(id: 1)).to be_blank
+
+        blog_shard1.create_author(id: 1)
+
         expect(blog_shard1.author).to be_present
-        expect(blog_shard1.author.blog_id).to eq(1)
-        expect(blog_shard1.articles.pluck(:id)).to eq([1, 2, 3])
+        expect(Author.shard(:shard01).find_by(id: 1)).to be_present
 
-        blog_shard2 = Blog.shard(:shard02).first
-        expect(blog_shard2.author).to be_present
-        expect(blog_shard2.author.blog_id).to eq(2)
-        expect(blog_shard2.articles.pluck(:id)).to eq([4, 5, 6])
+        blog_shard2 = Blog.shard(:shard02).create(id: 2)
+
+        expect(blog_shard2.author).to be_blank
+        author = blog_shard2.build_author(id: 2)
+
+        expect(author).to_not be_persisted
+        expect(author.current_shard).to eq(:shard02)
+
+        author.save!
+
+        expect(author).to be_persisted
+        expect(Author.shard(:shard02).find_by(id: 2)).to be_present
+      end
+    end
+  end
+
+  describe "AssociationRelation" do
+    it "works" do
+      user = User.shard(:shard01).create(id: 1)
+
+      expect(User.shard(:shard01).first).to eq(user)
+
+      Log.shard(:shard01).create(number: 1, user: user)
+      Log.shard(:shard01).create(number: 2, user: user)
+      Log.shard(:shard01).create(number: 3, user: user)
+
+      expect(Log.shard(:shard01).count).to eq(3)
+      expect(Log.shard(:shard01).number_gteq(2).reload.count).to eq(2)
+      expect(user.logs.count).to eq(3)
+      expect(user.logs.number_gteq(3).count).to eq(1)
+    end
+  end
+
+  describe "when ActiveRecord methods aliased" do
+    before do
+      ::ActiveRecord::Base.class_eval do
+        alias_method :save_alias, :save
+
+        def save(*args, &blk)
+          if true
+            save_alias(*args, &blk)
+          end
+        end
+      end
+    end
+
+    it "works" do
+      aggregate_failures do
+        normal_model = ModelA.shard(:shard01).create(id: 1)
+        normal_model.update_attributes(value1: 1)
+
+        expect(normal_model).to be_persisted
+
+        evil_model = SaveAlias.shard(:shard01).create(id: 1)
+        evil_model.update_attributes(value1: 1)
+
+        expect(evil_model).to be_persisted
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,13 +10,15 @@ Dir[File.join(File.dirname(__FILE__), '../', "spec/active_record/**/*.rb")].each
 
 RSpec.configure do |config|
   config.before(:suite) do
-
     migration_classes = [
       CreateModelA,
       CreateModelB,
       CreateUser,
       CreateWallet,
-      CreateLog
+      CreateLog,
+      CreateBlog,
+      CreateArticle,
+      CreateAuthor
     ]
 
     Tako.config[:test].values.each do |conf|
@@ -48,7 +50,10 @@ RSpec.configure do |config|
       ModelB,
       User,
       Wallet,
-      Log
+      Log,
+      Blog,
+      Article,
+      Author
     ].each do |klass|
       klass.delete_all
       klass.shard(:shard01).delete_all
@@ -62,7 +67,10 @@ RSpec.configure do |config|
       ModelB,
       User,
       Wallet,
-      Log
+      Log,
+      Blog,
+      Article,
+      Author
     ].each do |klass|
       klass.delete_all
       klass.shard(:shard01).delete_all

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'tako'
+require 'pry'
 
 ENV["RAILS_ENV"] ||= 'test'
 ENV['TAKO_CONFIG_FILE_PATH'] ||= "spec/config/shards.yml"
@@ -13,12 +14,19 @@ RSpec.configure do |config|
     migration_classes = [
       CreateModelA,
       CreateModelB,
+      CreateForceShardRoot,
+      CreateForceShardA,
+      CreateForceShardB,
       CreateUser,
       CreateWallet,
       CreateLog,
       CreateBlog,
       CreateArticle,
-      CreateAuthor
+      CreateAuthor,
+      CreateCharacter,
+      CreateSkill,
+      CreateCharacterSkill,
+      CreateSaveAliased
     ]
 
     Tako.config[:test].values.each do |conf|
@@ -48,12 +56,19 @@ RSpec.configure do |config|
     [
       ModelA,
       ModelB,
+      ForceShardRoot,
+      ForceShardA,
+      ForceShardB,
       User,
       Wallet,
       Log,
       Blog,
       Article,
-      Author
+      Author,
+      Character,
+      Skill,
+      CharacterSkill,
+      SaveAlias
     ].each do |klass|
       klass.delete_all
       klass.shard(:shard01).delete_all
@@ -65,12 +80,19 @@ RSpec.configure do |config|
     [
       ModelA,
       ModelB,
+      ForceShardRoot,
+      ForceShardA,
+      ForceShardB,
       User,
       Wallet,
       Log,
       Blog,
       Article,
-      Author
+      Author,
+      Character,
+      Skill,
+      CharacterSkill,
+      SaveAlias
     ].each do |klass|
       klass.delete_all
       klass.shard(:shard01).delete_all

--- a/spec/support/model_class.rb
+++ b/spec/support/model_class.rb
@@ -7,6 +7,29 @@ end
 class ModelB < ActiveRecord::Base
 end
 
+class ForceShardRoot < ActiveRecord::Base
+  has_many :force_shard_a
+  has_one :force_shard_b
+end
+
+class ForceShardA < ActiveRecord::Base
+  force_shard :shard01
+  belongs_to :force_shard_root
+end
+
+class ForceShardB < ActiveRecord::Base
+  force_shard :shard02
+  belongs_to :force_shard_root
+
+  def self.sharded_class_method(rid)
+    ForceShardB.create(force_shard_root_id: rid)
+  end
+
+  def sharded_method(rid)
+    ForceShardB.create(force_shard_root_id: rid)
+  end
+end
+
 class User < ActiveRecord::Base
   has_many :logs
   has_one :wallet
@@ -14,20 +37,11 @@ end
 
 class Wallet < ActiveRecord::Base
   belongs_to :user
-  force_shard :shard01
 end
 
 class Log < ActiveRecord::Base
   belongs_to :user
-  force_shard :shard02
-
-  def self.sharded_class_method(user_id)
-    Log.create(user_id: user_id)
-  end
-
-  def sharded_method(user_id)
-    Log.create(user_id: user_id)
-  end
+  scope :number_gteq, ->(val) { where("number >= ?", val) }
 end
 
 class Blog < ActiveRecord::Base
@@ -41,6 +55,24 @@ end
 
 class Author < ActiveRecord::Base
   belongs_to :blog
+end
+
+class Character < ActiveRecord::Base
+  has_many :skills, through: :character_skills
+  has_many :character_skills
+end
+
+class Skill < ActiveRecord::Base
+  has_many :characters, through: :character_skills
+  has_many :character_skills
+end
+
+class CharacterSkill < ActiveRecord::Base
+  belongs_to :character
+  belongs_to :skill
+end
+
+class SaveAlias < ActiveRecord::Base
 end
 
 class CreateModelA < ActiveRecord::Migration
@@ -60,6 +92,32 @@ class CreateModelB < ActiveRecord::Migration
       t.integer :value3
       t.string  :value4
 
+      t.timestamps null: false
+    end
+  end
+end
+
+class CreateForceShardRoot < ActiveRecord::Migration
+  def change
+    create_table :force_shard_roots do |t|
+      t.timestamps null: false
+    end
+  end
+end
+
+class CreateForceShardA < ActiveRecord::Migration
+  def change
+    create_table :force_shard_as do |t|
+      t.belongs_to :force_shard_root
+      t.timestamps null: false
+    end
+  end
+end
+
+class CreateForceShardB < ActiveRecord::Migration
+  def change
+    create_table :force_shard_bs do |t|
+      t.belongs_to :force_shard_root
       t.timestamps null: false
     end
   end
@@ -103,6 +161,7 @@ class CreateLog < ActiveRecord::Migration
   def change
     create_table :logs do |t|
       t.belongs_to :user
+      t.integer :number
       t.timestamps null: false
     end
   end
@@ -112,6 +171,41 @@ class CreateAuthor < ActiveRecord::Migration
   def change
     create_table :authors do |t|
       t.belongs_to :blog
+      t.timestamps null: false
+    end
+  end
+end
+
+class CreateCharacter < ActiveRecord::Migration
+  def change
+    create_table :characters do |t|
+      t.timestamps null: false
+    end
+  end
+end
+
+class CreateSkill < ActiveRecord::Migration
+  def change
+    create_table :skills do |t|
+      t.timestamps null: false
+    end
+  end
+end
+
+class CreateCharacterSkill < ActiveRecord::Migration
+  def change
+    create_table :character_skills do |t|
+      t.belongs_to :character
+      t.belongs_to :skill
+      t.timestamps null: false
+    end
+  end
+end
+
+class CreateSaveAliased < ActiveRecord::Migration
+  def change
+    create_table :save_aliases do |t|
+      t.integer :value1
       t.timestamps null: false
     end
   end

--- a/spec/support/model_class.rb
+++ b/spec/support/model_class.rb
@@ -30,6 +30,19 @@ class Log < ActiveRecord::Base
   end
 end
 
+class Blog < ActiveRecord::Base
+  has_many :articles
+  has_one :author
+end
+
+class Article < ActiveRecord::Base
+  belongs_to :blog
+end
+
+class Author < ActiveRecord::Base
+  belongs_to :blog
+end
+
 class CreateModelA < ActiveRecord::Migration
   def change
     create_table :model_as do |t|
@@ -60,6 +73,14 @@ class CreateUser < ActiveRecord::Migration
   end
 end
 
+class CreateBlog < ActiveRecord::Migration
+  def change
+    create_table :blogs do |t|
+      t.timestamps null: false
+    end
+  end
+end
+
 class CreateWallet < ActiveRecord::Migration
   def change
     create_table :wallets do |t|
@@ -69,10 +90,28 @@ class CreateWallet < ActiveRecord::Migration
   end
 end
 
+class CreateArticle < ActiveRecord::Migration
+  def change
+    create_table :articles do |t|
+      t.belongs_to :blog
+      t.timestamps null: false
+    end
+  end
+end
+
 class CreateLog < ActiveRecord::Migration
   def change
     create_table :logs do |t|
       t.belongs_to :user
+      t.timestamps null: false
+    end
+  end
+end
+
+class CreateAuthor < ActiveRecord::Migration
+  def change
+    create_table :authors do |t|
+      t.belongs_to :blog
       t.timestamps null: false
     end
   end

--- a/tako.gemspec
+++ b/tako.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
now ActiveRecord::Base's (or subclasses) instance have their shards when created.
You can access the created-shard from instance by ActiveRecord::Base#current_shard. 
Here is example of how works is that.

``` rb
User.first
#=> uses default connection

User.shard(:shard01).first
#=> uses :shard01 connection at shards.yml

user = User.shard(:shard01).first
Tako.shard(:shard02) do
  User.first
  #=> uses :shard02 connection at shards.yml

  user.update_attributes(hoge: "huga")
  #=> uses :shard01 connection at shards.yml
  user.current_shard
  #=> returns :shard01

  User.first.current_shard
  #=> returns :shard02
end
```
