### PR TITLE
remove old connections safely

### DIFF
--- a/lib/tako.rb
+++ b/lib/tako.rb
@@ -23,6 +23,7 @@ module Tako
     end
 
     def load_connections_from_yaml
+      Tako::Repository.clear
       (config[env] || []).each do |shard_name, conf|
         Tako::Repository.add(shard_name, conf)
       end

--- a/lib/tako/repository.rb
+++ b/lib/tako/repository.rb
@@ -9,6 +9,15 @@ module Tako
         @proxy_connections ||= {}
       end
 
+      def clear
+        proxy_connections.each do |shard_name, connection|
+          connection.disconnect!
+          remove_const("TAKO_AR_CLASS_#{shard_name.upcase}")
+        end
+        proxy_configs.clear
+        proxy_connections.clear
+      end
+
       def add(shard_name, conf)
         shard_name = shard_name.to_sym
         return if proxy_configs[shard_name]

--- a/spec/tako_spec.rb
+++ b/spec/tako_spec.rb
@@ -137,4 +137,22 @@ describe Tako do
       expect(ModelA.find_by(id: 2)).to be_nil
     end
   end
+
+  describe "load_connections_from_yaml" do
+    it "clears old connections" do
+      old_object_ids = [
+        ActiveRecord::Base.shard(:shard01).connection.object_id,
+        ActiveRecord::Base.shard(:shard02).connection.object_id
+      ]
+
+      Tako.load_connections_from_yaml
+
+      new_object_ids = [
+        ActiveRecord::Base.shard(:shard01).connection.object_id,
+        ActiveRecord::Base.shard(:shard02).connection.object_id
+      ]
+
+      expect(new_object_ids).to_not eq(old_object_ids)
+    end
+  end
 end


### PR DESCRIPTION
- Fix to remove old connections when Tako.load_connections_from_yaml called
