### PR TITLE
Set internal metadata at migration timing for rails 5

### DIFF
--- a/lib/tako/railties/databases.rake
+++ b/lib/tako/railties/databases.rake
@@ -46,6 +46,11 @@ namespace :db do
             ActiveRecord::SchemaMigration.create!(:version => proxy.version.to_s)
           end
         end
+
+        if defined?(ActiveRecord::InternalMetadata)
+          ActiveRecord::InternalMetadata.create_table
+          ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Migrator.current_environment
+        end
       end
     end
 


### PR DESCRIPTION
With rails 5, the migrator records internal metadata (environment information). But the `db:tako:migrate` task does not now.

By this change, the task will be able to set internal data with rails 5.

<img width="778" alt="ar_internal_metadata" src="https://cloud.githubusercontent.com/assets/38711/20469143/003c6a12-afe1-11e6-85c5-8de4adc7e281.png">
