### PR TITLE
Fix missing block arguments

### DIFF
--- a/lib/tako/query_chain.rb
+++ b/lib/tako/query_chain.rb
@@ -8,12 +8,10 @@ module Tako
       @base_object = base_object
     end
 
-    def method_missing(method, *args)
+    def method_missing(method, *args, &block)
       @proxy.with_shard do
         result = if block_given?
-                    base_object.send(method, *args) do
-                      yield
-                    end
+                    base_object.send(method, *args, &block)
                   else
                     base_object.send(method, *args)
                   end

--- a/spec/active_record/shard.rb
+++ b/spec/active_record/shard.rb
@@ -329,4 +329,13 @@ describe 'ActiveRecord::Base.shard' do
       end
     end
   end
+
+  describe "query chain method with block args" do
+    it "works" do
+      record = ModelA.shard(:shard01).find_or_initialize_by(id: 1) do |a|
+        a.value1 = 1
+      end
+      expect(record.value1).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
When calling a method with block against a `Tako::QueryChain` instance, it misses block arguments.
For example, 

```ruby
record = ModelA.shard(:shard01).find_or_initialize_by(id: 1) do |a|
  # This `a` should be an instance of `ModelA`, but is nil.
  a.value1 = 1
end
```