### PR TITLE
bump to 0.5.0

### DIFF
--- a/lib/tako/version.rb
+++ b/lib/tako/version.rb
@@ -1,3 +1,3 @@
 module Tako
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
* Supports `exists?` and methods that depends `calculate` via query chain at #28 by @a2ikm 
* Proxy `ActiveRecord::Relation#load` instead of higher API. at #29 by @a2ikm 