### PR TITLE
Support DATABASE_URL style configuration

### DIFF
--- a/spec/config/shards.yml
+++ b/spec/config/shards.yml
@@ -17,3 +17,6 @@ tako:
     shard02:
       <<: *default
       database: tako_test_shard2
+    shard03:
+      <<: *default
+      url: mysql2://<%= ENV['MYSQL_USER_NAME'] || "root" %>:<%= ENV['MYSQL_ROOT_PASSWORD'] %>@<%= ENV['MYSQL_HOST'] || "localhost" %>:<%= ENV['MYSQL_PORT'] || 3306 %>/tako_test_shard3

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,10 @@ RSpec.configure do |config|
       ActiveRecord::Migration.run(*migration_classes)
     end
 
+    Tako.shard(:shard03) do
+      ActiveRecord::Migration.run(*migration_classes)
+    end
+
     database_yml_path = File.join(File.dirname(__FILE__), "config/database.yml")
     database_yml = YAML.load(ERB.new(File.read(database_yml_path)).result).with_indifferent_access[:test]
     ActiveRecord::Tasks::DatabaseTasks.drop(database_yml)
@@ -57,6 +61,7 @@ RSpec.configure do |config|
       klass.delete_all
       klass.shard(:shard01).delete_all
       klass.shard(:shard02).delete_all
+      klass.shard(:shard03).delete_all
     end
   end
 
@@ -81,6 +86,7 @@ RSpec.configure do |config|
       klass.delete_all
       klass.shard(:shard01).delete_all
       klass.shard(:shard02).delete_all
+      klass.shard(:shard03).delete_all
     end
   end
 end

--- a/spec/tako_spec.rb
+++ b/spec/tako_spec.rb
@@ -61,6 +61,18 @@ describe Tako do
               host:     ENV['MYSQL_HOST'] || "localhost",
               port:     ENV['MYSQL_PORT'] || 3306,
               database: "tako_test_shard2"
+            },
+            shard03: {
+              adapter: "mysql2",
+              encoding: "utf8",
+              charset: "utf8",
+              collation: "utf8_unicode_ci",
+              reconnect: false,
+              username: ENV['MYSQL_USER_NAME'] || "root",
+              password: ENV['MYSQL_ROOT_PASSWORD'],
+              host:     ENV['MYSQL_HOST'] || "localhost",
+              port:     ENV['MYSQL_PORT'] || 3306,
+              database: "tako_test_shard3"
             }
           }
         }.with_indifferent_access
@@ -76,7 +88,8 @@ describe Tako do
       expect(subject).to eq(
         [
           :shard01,
-          :shard02
+          :shard02,
+          :shard03
         ]
       )
     end


### PR DESCRIPTION
This PR adds `DATABASE_URL` style configuration support to `config/shards.yml`.

I think passing all shards' urls is not realistic, but modifying `DATABASE_URL` for each shard is useful.
For example: 

```yml
tako:
  <%= Rails.env %>:
    shard01:
      <<: *default
      url: <%= ENV['DATABASE_URL'] %>_shard01
      
    shard02:
      <<: *default
      url: <%= ENV['DATABASE_URL'] %>_shard02
      
    master:
      <<: *default    
      url: <%= ENV['DATABASE_URL'] %>
```