### PR TITLE
Delay DB connecting until it becomes necessary

### DIFF
--- a/lib/tako/active_record_ext/connection_handling.rb
+++ b/lib/tako/active_record_ext/connection_handling.rb
@@ -14,5 +14,6 @@ module Tako
 end
 
 ActiveRecord::ConnectionHandling.class_eval do
+  alias_method :connection_without_tako, :connection
   prepend Tako::ActiveRecordExt::ConnectionHandling
 end

--- a/lib/tako/repository.rb
+++ b/lib/tako/repository.rb
@@ -5,17 +5,17 @@ module Tako
         @proxy_configs ||= {}
       end
 
-      def proxy_connections
-        @proxy_connections ||= {}
+      def proxy_classes
+        @proxy_classes ||= {}
       end
 
       def clear
-        proxy_connections.each do |shard_name, connection|
-          connection.disconnect!
+        proxy_classes.each do |shard_name, proxy_class|
+          proxy_class.connection.disconnect!
           remove_const("TAKO_AR_CLASS_#{shard_name.upcase}")
         end
         proxy_configs.clear
-        proxy_connections.clear
+        proxy_classes.clear
       end
 
       def add(shard_name, conf)
@@ -26,12 +26,12 @@ module Tako
         const_set("TAKO_AR_CLASS_#{shard_name.upcase}", temporary_class)
         temporary_class.establish_connection(conf)
 
-        proxy_connections[shard_name] = temporary_class.connection
+        proxy_classes[shard_name] = temporary_class
         proxy_configs[shard_name] = conf
       end
 
       def create_proxy(shard_name)
-        Proxy.new(shard_name, proxy_connections[shard_name.to_sym])
+        Proxy.new(shard_name, proxy_classes[shard_name.to_sym].connection_without_tako)
       end
 
       def shard_names


### PR DESCRIPTION
Currently Tako establishes connections with shards at booting up.
This PR changes it to at executing first query.

Furthermore, this enables refreshing connections by each request with [activerecord-refresh_connection](https://github.com/sonots/activerecord-refresh_connection).

Note that these changes are made by @hoco, who is my co-worker.
Thanks @hoco!