### PR TITLE
Fix db:tako:migrate fails in Rails 5.2

### DIFF
--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "activerecord", "~> 4.2.0"
+gem "rails", "~> 4.2.0"
 gem "mysql2", ">= 0.3.13", "< 0.5"
 
 gemspec :path => "../"

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem "activerecord", "~> 5.0.0"
+gem "rails", "~> 5.0.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails_51.gemfile
+++ b/gemfiles/rails_51.gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem "activerecord", "~> 5.1.0"
+gem "rails", "~> 5.1.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails_52.gemfile
+++ b/gemfiles/rails_52.gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem "activerecord", "~> 5.2.0"
+gem "rails", "~> 5.2.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-gem "activerecord", :github => "rails/rails"
+gem "rails", :github => "rails/rails"
 
 gemspec :path => "../"

--- a/spec/fake_app.rb
+++ b/spec/fake_app.rb
@@ -1,0 +1,11 @@
+require 'rails'
+require 'active_record/railtie'
+
+class FakeApp < Rails::Application
+  config.secret_key_base = config.secret_token = [*'A'..'z'].join
+  config.session_store :cookie_store, :key => '_myapp_session'
+  config.active_support.deprecation = :log
+  config.eager_load = false
+  config.root = __dir__
+end
+FakeApp.initialize!

--- a/spec/rake_spec.rb
+++ b/spec/rake_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+require "rake"
+
+describe "Rake tasks" do
+  before(:all) do
+    Rake.application.rake_require "tako/railties/databases"
+    Rails.application.load_tasks
+  end
+  describe "db:tako:migrate" do
+    before do
+      Rake::Task["db:tako:migrate"].reenable
+    end
+    it "works" do
+      Rake::Task["db:tako:migrate"].invoke
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
+ENV["RAILS_ENV"] ||= 'test'
+require_relative 'fake_app'
+
 require 'tako'
 require 'pry'
-
-ENV["RAILS_ENV"] ||= 'test'
-ENV['TAKO_CONFIG_FILE_PATH'] ||= "spec/config/shards.yml"
 
 Dir[File.join(File.dirname(__FILE__), '../', "spec/support/**/*.rb")].each { |f| require f }
 Dir[File.join(File.dirname(__FILE__), '../', "spec/active_record/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
`ActiveRecord::Migrator` was refactored at https://github.com/rails/rails/commit/a2827ec9811b5012e8e366011fd44c8eb53fc714.

This PR add a fake Rails app to run rake tasks in tests.
I think this makes an impact to testing environment.
So if you think no tests for rake tasks are ok and want to remove them, let me know please.
(For example, rails doesn't have tests for rake tasks)

Sorry, these changes should be included in #24 XO